### PR TITLE
show an example of the thing

### DIFF
--- a/_components/the-thing.webc
+++ b/_components/the-thing.webc
@@ -1,0 +1,1 @@
+<p><slot>The thing</slot></p>

--- a/index.html
+++ b/index.html
@@ -8,5 +8,7 @@
 
 	<body>
 		<h1>Hello</h1>
+		<the-thing></the-thing>
+		<the-thing>Another thing</the-thing>
 	</body>
 </html>


### PR DESCRIPTION
This example PR shows how to add a [WebC component](https://www.11ty.dev/docs/languages/webc/#usage) to a page. As configured in the `.eleventy.js` file, any `.webc` files defined inside `_components/` are automatically picked up.