### PR TITLE
basic DSD example

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ export default function (eleventyConfig) {
 	eleventyConfig.addPlugin(pluginWebc, {
 		components: ["_components/**/*.webc"],
 	});
+	eleventyConfig.setServerOptions({ domDiff: false });
 
 	return {
 		htmlTemplateEngine: "webc",

--- a/_components/dsd-test.webc
+++ b/_components/dsd-test.webc
@@ -1,0 +1,22 @@
+<div webc:root="override">
+	<template shadowrootmode="open">
+		<p>Inside the shadow-root</p>
+		
+		<slot webc:keep>This is the shadow DOM slot</slot>
+		<slot name="shadow">This is the WebC slot?</slot>
+
+		<!-- paragraphs inside shadow-root will be italic -->
+		<style webc:keep>
+			p { font-style: italic; }
+		</style>
+	</template>
+
+	<p>Outside the shadow-root</p>
+	
+	<slot>WebC slot outside the shadow-root</slot>
+</div>
+
+<!-- paragraphs in this file outside the shadow-root will be bold -->
+<style webc:scoped>
+	p { font-weight: bold; }
+</style>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,15 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
 		<title>11ty</title>
+
+		<style @raw="getBundle('css')" webc:keep></style>
 	</head>
 
 	<body>
 		<h1>Hello</h1>
+		<dsd-test>
+			Slotted into light DOM
+			<p slot="shadow">Slotted into shadow DOM</p>
+		</dsd-test>
 	</body>
 </html>


### PR DESCRIPTION
This is a basic, somewhat broken example of using declarative shadow DOM inside a WebC component.

Notably, WebC leaves behind a `slot` attribute in the WebC-slotted element.

<img width="639" alt="" src="https://github.com/user-attachments/assets/924eb86c-4a31-4694-b853-d69f6011e78f">
